### PR TITLE
Header fix for Phoenix 0.13.1

### DIFF
--- a/lib/blaguth.ex
+++ b/lib/blaguth.ex
@@ -44,7 +44,7 @@ defmodule Blaguth do
     do: halt_with_login(conn, realm)
 
   def halt_with_login(conn, realm) do
-    Conn.put_resp_header(conn, "Www-Authenticate", "Basic realm=\"" <> realm <> "\"")
+    Conn.put_resp_header(conn, "www-authenticate", "Basic realm=\"" <> realm <> "\"")
     |> Conn.send_resp(401, "HTTP Basic: Access denied.\n")
     |> Conn.halt
   end

--- a/test/blaguth_test.exs
+++ b/test/blaguth_test.exs
@@ -46,7 +46,7 @@ defmodule BlaguthTest do
 
   defp assert_unauthorized(conn, realm) do
     assert conn.status == 401
-    assert get_resp_header(conn, "Www-Authenticate") == ["Basic realm=\"" <> realm <> "\""]
+    assert get_resp_header(conn, "www-authenticate") == ["Basic realm=\"" <> realm <> "\""]
     refute conn.assigns[:logged_in]
   end
 


### PR DESCRIPTION
I installed clean Phoenix version together with blaguth. No luck to make it work because of bad formatted header (the error said that capital letters are not allowed). I guess because of newer phoenix/plug.
